### PR TITLE
[CI] Label commenter workflow added

### DIFF
--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -1,0 +1,27 @@
+comment:
+  footer: "\
+    ---\n\n
+    > &nbsp; &#9; &nbsp; &#9;  &nbsp; &#9;  &nbsp; &#9; Be sure to [join the community](http://slack.layer5.io), if you haven't yet and please leave a :star: [star on the project](../stargazers) :smile: on the project.
+    "
+
+labels:
+  - name: issue/design required
+    labeled:
+      issue:
+        body: This issue has been labeled with 'design-required'. Note that prior to commencing on implementation, a design specification needs to be created and reviewed for approval. See [Creating a Functional Specification](https://docs.google.com/document/d/1RP3IWLc-MiQS-QYasqCoVuCH7--G87p5ezE5f_nOzB8/edit?usp=sharing) to create a design spec.
+        action: open
+  - name: issue/remind
+    labeled:
+      issue:
+        body: Checking in... it has been awhile since we&#39;ve heard from you on this issue. Are you still working on it? Please let us know and please don&#39;t hesitate to contact a [MeshMate](https://layer5.io/community/meshmates/) or any other [community member](https://layer5.io/community/members) for assistance.
+        action: open
+      pr: 
+        body: Checking in... it has been awhile since we&#39;ve heard from you on this issue. Are you still working on it? Please let us know and please don&#39;t hesitate to contact a [MeshMate](https://layer5.io/community/meshmates/) or any other [community member](https://layer5.io/community/members) for assistance.
+        action: open
+  - name: issue/dco
+    labeled:
+      pr:
+      body: "🚨 Alert! Git Police! We couldn’t help but notice that one or more of your commits is missing a sign-off. _A what?_ A commit sign-off (your email address).\n\n
+        To amend the commits in this PR with your signoff using the instructions provided in the DCO check above. \n\n
+        To configure your dev environment to automatically signoff on your commits in the future, see [these instructions](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)."
+      action: open

--- a/.github/label-commenter-config.yml
+++ b/.github/label-commenter-config.yml
@@ -21,7 +21,7 @@ labels:
   - name: issue/dco
     labeled:
       pr:
-      body: "🚨 Alert! Git Police! We couldn’t help but notice that one or more of your commits is missing a sign-off. _A what?_ A commit sign-off (your email address).\n\n
+        body: "🚨 Alert! Git Police! We couldn’t help but notice that one or more of your commits is missing a sign-off. _A what?_ A commit sign-off (your email address).\n\n
         To amend the commits in this PR with your signoff using the instructions provided in the DCO check above. \n\n
         To configure your dev environment to automatically signoff on your commits in the future, see [these instructions](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)."
-      action: open
+        action: open

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -1,0 +1,26 @@
+name: Label Commenter
+
+on:
+  issues:
+    types:
+      - labeled
+
+  pull_request_target:
+    types:
+      - labeled
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master # Set your default branch
+
+      - name: Label Commenter
+        uses: peaceiris/actions-label-commenter@v1


### PR DESCRIPTION
Signed-off-by: amino19 <anshumaankrprasad76@gmail.com>

**Description**
Added CI workflow for `Label Comments`

This PR fixes #240 

**Notes for Reviewers**
Only added configuration for [issue/remind](https://github.com/meshery/meshery/blob/88d1c7c559259775ce2affab2a15a32c673c3f52/.github/label-commenter-config.yml#L14-L18).
Pl suggest, if we need to include any other configs as well!

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
