### PR TITLE
css unit fix

### DIFF
--- a/docs/assets/css/responsive.css
+++ b/docs/assets/css/responsive.css
@@ -2,7 +2,7 @@
 
 @media screen and (max-width: 992px) {
   .footer {
-      padding-left: 8p;
+      padding-left: 8px;
       text-align: left;
   }
 }


### PR DESCRIPTION
**Description**

Fix typo use correct CSS unit for padding i.e. `px` instead of `p`

This PR fixes #282

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
