### PR TITLE
fix: the pipeline service mesh performance was not responsive for smaller width

### DIFF
--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -83,7 +83,7 @@
     %} {{ page.date | date: date_format }}
       </time>
     </p>
-    <div class="card mt-1 mb-5 p-5 shadow-lg">
+    <div class="card mt-1 mb-5 p-5 shadow-lg post-card">
       {{ content }}
     </div>
   </div>

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -83,7 +83,7 @@
     %} {{ page.date | date: date_format }}
       </time>
     </p>
-    <div class="card mt-1 mb-5 p-5 shadow-lg>
+    <div class="card mt-1 mb-5 p-5 shadow-lg">
       {{ content }}
     </div>
   </div>

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -83,7 +83,7 @@
     %} {{ page.date | date: date_format }}
       </time>
     </p>
-    <div class="card mt-1 mb-5 p-5 shadow-lg post-card">
+    <div class="card mt-1 mb-5 p-5 shadow-lg>
       {{ content }}
     </div>
   </div>

--- a/docs/_sass/layout/_about.scss
+++ b/docs/_sass/layout/_about.scss
@@ -239,8 +239,8 @@ pre code {
 div.codewrapper {
   min-width: 60%;
   height: auto;
-  margin-left: auto;
-  margin-right: auto;
+  margin-left:auto;
+  margin-right:auto;
   text-align: center;
   display: block;
   >.code-caption {

--- a/docs/_sass/layout/_about.scss
+++ b/docs/_sass/layout/_about.scss
@@ -188,7 +188,7 @@ div.about-body {
       &.about-inverted > .about-panel {
         padding: 0 20px 20px;
       }
-    }
+    } 
   }
 }
 @media(min-width:1200px) {
@@ -239,17 +239,17 @@ pre code {
 div.codewrapper {
   min-width: 60%;
   height: auto;
-  margin-left:auto;
-  margin-right:auto;
+  margin-left: auto;
+  margin-right: auto;
   text-align: center;
   display: block;
-  > .code-caption {
+
+  .codewrapper > .code-caption {
     font-style: italic;
     font-size: 1em;
     color: $gray-600;
   }
 }
-
 div.videowrapper {
   min-width: 80%;
   height: auto;
@@ -288,4 +288,23 @@ div.deckwrapper {
   text-align: center;
   position: relative;
   justify-content:center;
+}
+
+
+@media (max-width: 991px){
+  div.codewrapper{
+    margin-left:0;
+    margin-right: 0;
+    background-color: #111;
+  }
+
+  .code-caption{
+    background-color: white;
+    padding: 30px 0px;
+  }
+
+  div.deckwrapper{
+    margin-top: -65px;
+
+  }
 }

--- a/docs/_sass/layout/_about.scss
+++ b/docs/_sass/layout/_about.scss
@@ -243,7 +243,7 @@ div.codewrapper {
   margin-right: austo;
   text-align: center;
   display: block;
-  .code-caption {
+  >.code-caption {
     font-style: italic;
     font-size: 1em;
     color: $gray-600;

--- a/docs/_sass/layout/_about.scss
+++ b/docs/_sass/layout/_about.scss
@@ -240,11 +240,10 @@ div.codewrapper {
   min-width: 60%;
   height: auto;
   margin-left: auto;
-  margin-right: auto;
+  margin-right: austo;
   text-align: center;
   display: block;
-
-  .codewrapper > .code-caption {
+  .code-caption {
     font-style: italic;
     font-size: 1em;
     color: $gray-600;

--- a/docs/_sass/layout/_about.scss
+++ b/docs/_sass/layout/_about.scss
@@ -240,7 +240,7 @@ div.codewrapper {
   min-width: 60%;
   height: auto;
   margin-left: auto;
-  margin-right: austo;
+  margin-right: auto;
   text-align: center;
   display: block;
   >.code-caption {


### PR DESCRIPTION
**Description**

This PR fixes #429 
I have fixed this issue by adding some media queries on ``cards``.
The was the width of ``code-wrapper `` was too large that was causing overflowing of contents like ``navbar`` and ``code-wrapper`` itself

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
